### PR TITLE
Status entry in the OAuthTokenResponse

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.apifest</groupId>
     <artifactId>apifest-client</artifactId>
-    <version>0.0.3</version>
+    <version>0.0.3-SNAPSHOT</version>
     <dependencies>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.apifest</groupId>
     <artifactId>apifest-client</artifactId>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.0.3</version>
     <dependencies>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>

--- a/src/main/java/com/apifest/client/OAuthTokenResponse.java
+++ b/src/main/java/com/apifest/client/OAuthTokenResponse.java
@@ -7,6 +7,7 @@ public class OAuthTokenResponse {
     String scope;
     String refresh_token;
     String error;
+    String status;
 
     public String getAccess_token() {
         return access_token;
@@ -47,13 +48,23 @@ public class OAuthTokenResponse {
     public void setRefresh_token(String refresh_token) {
         this.refresh_token = refresh_token;
     }
-    
+
     public String getError() {
         return error;
     }
 
     public void setError(String error) {
         this.error = error;
+    }
+
+    public String getStatus()
+    {
+        return status;
+    }
+
+    public void setStatus(String status)
+    {
+        this.status = status;
     }
 
 }


### PR DESCRIPTION
When a user queries apifest-oauth for a token with scope that he does not have access to apifest-oauth returns {"status":"scope not valid"}. Since the POJO does not have such a property, jax-rs panics and fails which results in an Internal Server Error. I added the status entry in the POJO to prevent this issue.
