### PR TITLE
[Issue #3] Refresh token grant type is currently not supported by the apifest-client

### DIFF
--- a/src/main/java/com/apifest/client/OAuthClient.java
+++ b/src/main/java/com/apifest/client/OAuthClient.java
@@ -78,7 +78,8 @@ public class OAuthClient {
                                                                        tokenRequest.getClient_id(),
                                                                        tokenRequest.getClient_secret(),
                                                                        tokenRequest.getUsername(),
-                                                                       tokenRequest.getPassword());
+                                                                       tokenRequest.getPassword(),
+                                                                       tokenRequest.getRefresh_token());
         if (response.getStatus() != 200 && response.getStatus() != 400) {
             return null;
         }

--- a/src/main/java/com/apifest/client/OAuthServer.java
+++ b/src/main/java/com/apifest/client/OAuthServer.java
@@ -61,7 +61,8 @@ public interface OAuthServer {
                         @FormParam("client_id") String clientId,
                         @FormParam("client_secret") String clientSecret,
                         @FormParam("username") String username,
-                        @FormParam("password") String password);
+                        @FormParam("password") String password,
+                        @FormParam("refresh_token") String refreshToken);
 
     @Path("/tokens/revoke")
     @POST

--- a/src/main/java/com/apifest/client/TokenRequest.java
+++ b/src/main/java/com/apifest/client/TokenRequest.java
@@ -29,6 +29,8 @@ public class TokenRequest {
 
     private String password;
 
+    private String refresh_token;
+
     public String getUsername() {
         return username;
     }
@@ -77,4 +79,11 @@ public class TokenRequest {
         this.client_secret = client_secret;
     }
 
+    public String getRefresh_token() {
+        return refresh_token;
+    }
+
+    public void setRefresh_token(String refresh_token) {
+        this.refresh_token = refresh_token;
+    }
 }


### PR DESCRIPTION
Add refresh_token in OAuthClient.